### PR TITLE
slacksocket changed to using Queue.

### DIFF
--- a/madcow/protocol/slack.py
+++ b/madcow/protocol/slack.py
@@ -42,7 +42,7 @@ class SlackProtocol(Madcow):
             try:
                 self.check_response_queue()
                 try:
-                    event = self.slack._eventq.pop(0)
+                    event = self.slack._eventq.get(False)
                 except IndexError:
                     time.sleep(.2)
                 else:


### PR DESCRIPTION
Some time in the last few releases, SlackSocket moved to using Queue instead of a simple list object for queued changes.

This change ensures Queue is non-blocking, and returns the first on the stack.